### PR TITLE
Implement mouse wheel in demo central directory list box

### DIFF
--- a/source/input.cc
+++ b/source/input.cc
@@ -37,6 +37,7 @@ Input::Input()
   mouse.quel = -1;
   for (int i = 0; i < 4; ++i)
     mouse.button[i] = RELEASED;
+  mouse.wheel = 0;
   clear_key();
 }
 
@@ -132,6 +133,10 @@ public:
               SDL_Log("unknown window event: %i", event.window.event);
           }
           break;
+
+	case SDL_MOUSEWHEEL:
+	  mouse.wheel = event.wheel.y;
+	  break;
 
         // Ignore these events.
         case SDL_FINGERDOWN:

--- a/source/input.h
+++ b/source/input.h
@@ -36,6 +36,7 @@ public:
   struct {
     uint8_t button[4];
     int quel;
+    int wheel;
   } mouse;
   int key_pending;
   struct {

--- a/source/listbox.cc
+++ b/source/listbox.cc
@@ -164,8 +164,7 @@ void Zone_listbox::process() {
 	Zone_watch_int::process();
 	if(input) {
 		if(cursor->x > x && cursor->x < x+w && cursor->y > y && cursor->y < y+h) {
-			// FIXME: this should be set to a mouse wheel delta.
-			int z = 0;
+			int z = input->mouse.wheel;
 			if(z > 0)
 				zup->clicked(0);
 			if(z < 0)


### PR DESCRIPTION
This commits makes possible to navigate in the menu central directory box using the mouse wheel. Tested on Linux
