### PR TITLE
Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /source/stamp-h1
 /test_version
 /wadder
+Quadra.app

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ A common problem on Mac OS X is that the libpng library is not available. This
 is relatively easy to work around, by downloading the libpng sources (available
 at http://www.libpng.org/pub/png/libpng.html), compiling them (no need to
 install it on your system!) and then adding a ```CPPFLAGS=-I/path/to/libpng
-LDFLAGS=-LCPPFLAGS=-I/path/to/libpng/.libs``` to the ```configure``` command
-line. It's possible that the LIBS variable will have to be adjusted in the
-Makefile, depending on the libpng version.
+LDFLAGS=-L/path/to/libpng/.libs``` to the ```configure``` command line. It's 
+possible that the LIBS variable will have to be adjusted in the Makefile, 
+depending on the libpng version. 
 
 Any questions?
 --------------

--- a/source/menu_demo_central.cc
+++ b/source/menu_demo_central.cc
@@ -361,8 +361,12 @@ void Menu_demo_central::step() {
 			if(!strcmp(e->list_name, "..")) {
 				// treat the .. differently
 				char *t = strrchr(find_directory, '/');
-				if(t)
+				if(t) {
 					*t = 0;
+					// test if it is the last folder
+					if (strlen(find_directory) == 0)
+						strcat(find_directory, "/");
+				}
 			}
 			else {
 				strcat(find_directory, "/");


### PR DESCRIPTION
When “..” was pressed in demo central and it was the last folder, a “terminating with uncaught exception of type boost::filesystem::filesystem_error: boost::filesystem::directory_iterator::construct: No such file or directory” occur. This patch fix this

(sorry for the last pull request, I messed up)
