### PR TITLE
make it possible to unpause on macOS

### DIFF
--- a/source/input.cc
+++ b/source/input.cc
@@ -100,7 +100,7 @@ public:
           keys[event.key.keysym.scancode] |= PRESSED;
           last_keysym = event.key.keysym;
 
-          if (event.key.keysym.sym == SDLK_PAUSE)
+          if (event.key.keysym.sym == SDLK_PAUSE || event.key.keysym.sym == SDLK_p)
               pause = true;
 
           if (!israw && key_pending < MAXKEY) {


### PR DESCRIPTION
It's hard to press `SDLK_PAUSE` on macOS making it almost impossible to start a multiplayer game. Adding another key, `p`, makes it possible to unpause a multiplayer game on macOS.